### PR TITLE
adds support of special characters and respective tests

### DIFF
--- a/lib/song_pro.rb
+++ b/lib/song_pro.rb
@@ -11,7 +11,8 @@ module SongPro
   SECTION_REGEX = /#\s*([^$]*)/
   ATTRIBUTE_REGEX = /@(\w*)=([^%]*)/
   CUSTOM_ATTRIBUTE_REGEX = /!(\w*)=([^%]*)/
-  CHORDS_AND_LYRICS_REGEX = %r{(\[[\w#b\/]+\])?([\w\s',.!()_\-"]*)}i
+  CHORDS_AND_LYRICS_REGEX = %r{(\[[\w#b\/]+\])?([^\[]*)}i
+
   MEASURES_REGEX = %r{([\[[\w#b\/]+\]\s]+)[|]*}i
   CHORDS_REGEX = %r{\[([\w#b\/]+)\]?}i
   COMMENT_REGEX = />\s*([^$]*)/

--- a/spec/song_pro_spec.rb
+++ b/spec/song_pro_spec.rb
@@ -74,6 +74,15 @@ RSpec.describe SongPro do
       expect(song.sections[0].lines[0].parts.size).to eq 1
       expect(song.sections[0].lines[0].parts[0].lyric).to eq 'singing something (something else)'
     end
+
+    it 'handles special characters' do
+      song = SongPro.parse('singing sömething with Röck dots')
+
+      expect(song.sections.size).to eq 1
+      expect(song.sections[0].lines.size).to eq 1
+      expect(song.sections[0].lines[0].parts.size).to eq 1
+      expect(song.sections[0].lines[0].parts[0].lyric).to eq 'singing sömething with Röck dots'
+    end
   end
 
   context 'chords' do


### PR DESCRIPTION
In the original regex, a lyrics part would be split by special characters like ä, ö, ü.
The old regex was whitelisting characters that are in a piece of lyrics. The new regex is blacklisting when a piece of lyrics should be split: on the chords.

Rspec tests are all green.