### PR TITLE
Fix incorrect attribute in example and add chords method example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ puts song.title
 puts song.artist
 # Brian Kelly
 
-puts song.sections[1].title
+puts song.sections[1].name
 # Chorus 1
+
+p song.chords
+# ["D", "A", "Bm", "F#m", "G", "Asus4", "A7", "F#"]
 ```
 
 ## Development


### PR DESCRIPTION
We were using `title` instead of `name` for sections.

Figured I'd also show off the `chords` method while I was at it.